### PR TITLE
added missing include for <new> that clang was complaining about

### DIFF
--- a/NativeImport.hpp
+++ b/NativeImport.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdexcept>
+#include <new>
 #include <amx/amx.h>
 
 #if defined __cplusplus


### PR DESCRIPTION
the following error was being thrown at build time:
```
    error: no member named 'bad_alloc' in namespace 'std'
      throw std::bad_alloc();
```
after a quick google this was voted as the solution and it _does_
build though I am not completely confident it won't break builds
for other machines/compilers (this was clang on mac).