### PR TITLE
Change std::string & cast size.

### DIFF
--- a/Internal/NativeCast.hpp
+++ b/Internal/NativeCast.hpp
@@ -410,7 +410,7 @@ namespace pawn_natives
 			return value_;
 		}
 
-		static constexpr int Size = 1;
+		static constexpr int Size = 2;
 
 	private:
 		int


### PR DESCRIPTION
Currently, the std::string & cast has the size of 1 (just the string) when it uses the size of 2, (string & the length param). This can result in a segmentation fault if you're trying to use two strings in one native.